### PR TITLE
rewrite origin header during proxy

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,7 @@ const { getUsing, sendError }  = require('./helpers');
 
 function main() {
   try {
-    const proxy = httpProxy.createProxyServer({ secure: false });
+    const proxy = httpProxy.createProxyServer({ secure: false, changeOrigin: true });
     const server = http.createServer(handler(proxy));
     console.log(`Listening on port ${port}...`);
     server.listen(port);
@@ -48,7 +48,7 @@ function handler(proxy) {
       gateway = siaGateway;
       rawHash = hash.substring(siaPrefix.length);
     }
-    
+
     try {
       logger.info(`Proxying ${domainName} => ${hash}\n`);
       proxy.web(req, res, {


### PR DESCRIPTION
I have setup my local environment and intermittently even safe names (anthony/) were failing. (The proxy server was chrashing) but not always. 

```

2021-06-17 12:41:12.050:  hdns: successfully resolved "xtreme-audio"
2021-06-17 12:41:12.051:  Proxying xtreme-audio => sia://zAAx8tKjeW8qsL7cFLcW-_ISqKfqzXz4cyRWadZgeP2E0w

/Users/rozaydin/Projects/namebase/sia-handshake-gateway/node_modules/http-proxy/lib/http-proxy/index.js:120
    throw err;
    ^

Error: write EPROTO 4559687168:error:14094438:SSL routines:ssl3_read_bytes:tlsv1 alert internal error:../deps/openssl/openssl/ssl/record/rec_layer_s3.c:1544:SSL alert number 80

    at WriteWrap.onWriteComplete [as oncomplete] (internal/stream_base_commons.js:92:16) {
  errno: 'EPROTO',
  code: 'EPROTO',
  syscall: 'write'
}

Process finished with exit code 1
```

Doing calls with wget reported an ssl tunneling error as below:

```
roza-mac-pro:~ rozaydin$ wget https://anthony/
--2021-06-17 13:00:20--  https://anthony/
Connecting to 52.43.158.89:80... connected.
Proxy tunneling failed: Bad RequestUnable to establish SSL connection.

roza-mac-pro:~ rozaydin$ wget http://anthony/ --server-response
--2021-06-17 13:04:04--  http://anthony/
Connecting to 52.43.158.89:80... connected.
Proxy request sent, awaiting response...
  HTTP/1.1 302 Found
  Server: nginx/1.18.0
  Date: Thu, 17 Jun 2021 10:04:05 GMT
  Transfer-Encoding: chunked
  Connection: keep-alive
  Location: https://siasky.net/3AH-35l_sJs1HmGa5L0K4oGGIZqBRp1tL7xu67Ir2aZ-cA
Location: https://siasky.net/3AH-35l_sJs1HmGa5L0K4oGGIZqBRp1tL7xu67Ir2aZ-cA [following]
--2021-06-17 13:04:05--  https://siasky.net/3AH-35l_sJs1HmGa5L0K4oGGIZqBRp1tL7xu67Ir2aZ-cA
Connecting to 52.43.158.89:80... connected.
Proxy tunneling failed: Bad RequestUnable to establish SSL connection.
```

I have update proxy-server's config to rewrite origin header. and tried to query the same names, this time the SSL errors got resolved.

```
roza-mac-pro:~ rozaydin$ wget http://saraba/ --server-response
--2021-06-17 13:08:16--  http://saraba/
Connecting to 52.43.158.89:80... connected.
Proxy request sent, awaiting response...
  HTTP/1.1 200 OK
  Server: nginx/1.18.0
  Date: Thu, 17 Jun 2021 10:08:18 GMT
  Content-Type: text/html
  Content-Length: 42195
  Connection: keep-alive
  accept-ranges: bytes
  access-control-allow-credentials: true
  access-control-allow-headers: DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,X-HTTP-Method-Override,upload-offset,upload-metadata,upload-length,tus-version,tus-resumable,tus-extension,tus-max-size,location
  access-control-allow-methods: GET, POST, HEAD, OPTIONS, PUT, PATCH, DELETE
  access-control-expose-headers: Content-Length,Content-Range,Skynet-File-Metadata,Skynet-Skylink,Skynet-Portal-Api,upload-offset,upload-metadata,upload-length,tus-version,tus-resumable,tus-extension,tus-max-size,location
  content-disposition: inline; filename="index.html"
  etag: "2e97c2c5dc2333346987c2539c2d1e7374c3a41ef370bce748612449ce8531a0"
  skynet-portal-api: https://siasky.net
  skynet-skylink: JADsDu75AtcLgh1x7PQ0tQJVOfj3nxZgYfJL7q9x3AH_BA
  vary: Accept-Encoding
  x-proxy-cache: MISS
Length: 42195 (41K) [text/html]
Saving to: ‘index.html.3’

index.html.3                100%[==========================================>]  41,21K   103KB/s    in 0,4s

2021-06-17 13:08:18 (103 KB/s) - ‘index.html.3’ saved [42195/42195]
```

I have hotfixed the prod machine and left it as it is. (After verifying it's resolving names) hotfix is set to false. and the origin rewrite header is set to true. It seems to be working.


Signed-off-by: rozaydin <ridvan@namebase.io>